### PR TITLE
Deepspeed stage3 warnings

### DIFF
--- a/ocpmodels/common/data_parallel.py
+++ b/ocpmodels/common/data_parallel.py
@@ -56,9 +56,7 @@ class OCPDataParallel(torch.nn.DataParallel):
             return self.module(batch_list[0])
 
         if len(self.device_ids) == 1:
-            x = batch_list[0]
-            y = x.to(f"cuda:{self.device_ids[0]}")
-            return self.module(y)
+            return self.module(batch_list[0].to(f"cuda:{self.device_ids[0]}"))
 
         for t in chain(self.module.parameters(), self.module.buffers()):
             if t.device != self.src_device:

--- a/ocpmodels/common/data_parallel.py
+++ b/ocpmodels/common/data_parallel.py
@@ -56,7 +56,9 @@ class OCPDataParallel(torch.nn.DataParallel):
             return self.module(batch_list[0])
 
         if len(self.device_ids) == 1:
-            return self.module(batch_list[0].to(f"cuda:{self.device_ids[0]}"))
+            x = batch_list[0]
+            y = x.to(f"cuda:{self.device_ids[0]}")
+            return self.module(y)
 
         for t in chain(self.module.parameters(), self.module.buffers()):
             if t.device != self.src_device:

--- a/ocpmodels/common/deepspeed_utils.py
+++ b/ocpmodels/common/deepspeed_utils.py
@@ -9,6 +9,11 @@ def initialize_deepspeed_data(*args, deepspeed_config=None):
     that is needed by DeepSpeed for the configuration defined in self.deepspeed_config.
     This function should be specifically used for data tensors or quantities based on the data
     which are of floating point type and will not be changed during the forward pass.
+
+    Args:
+        *args (List[torch.Tensor]): Tensors to be typecasted.
+        deepspeed_config (Path, optional): Path to the DeepSpeed config file in which
+            the information about type conversions is stored.
     """
     if len(args) > 1:
         return (deepspeed_convert_type(x, deepspeed_config) for x in args)
@@ -20,6 +25,11 @@ def deepspeed_convert_type(x, deepspeed_config=None):
     """
     Converts torch tensors to the needed data type for the specified deepspeed config
     json file. If no file path is passed, just the tensor itself will be returned.
+
+    Args:
+        x (torch.Tensor): Tensor to be converted.
+        deepspeed_config (Path, optional): Path to the DeepSpeed config file in which
+            the information about type conversions is stored.
     """
     if deepspeed_config is None:
         return x
@@ -35,6 +45,18 @@ def deepspeed_convert_type(x, deepspeed_config=None):
 
 
 def deepspeed_trainer_forward(func):
+    """
+    Decorator for a forward function using inputs of type torch_geometric.data.batch.Batch. This object is not suited for
+    DeepSpeed Stage 3 training and using it as input of a forward function will cause multiple warning printouts since the
+    tensors in the object are not detected by DeepSpeed. Although training seems to work without wrapping the Batch objects,
+    the countless warnings might be bothersome. The Batch objects are wrapped in such a way that they are of type dict as
+    well. As a dict, the parameters can be detected by DeepSpeed.
+
+    Args:
+        func: Method of a class taking self and batch_list (aribitrarily nested lists/tuples of torch_geometric.data.batch.Batch
+        objects).
+    """
+
     def inner(self, batch_list):
         with open(self.config["deepspeed_config"], "r") as config_file:
             config = json.load(config_file)
@@ -52,6 +74,10 @@ def deepspeed_trainer_forward(func):
 
 
 def recursive_batch_wrap(batch_list):
+    """
+    Wrap an arbitrarily nested list/tuple of torch_geometric.data.batch.Batch objects as Stage3BatchWrapper so that they
+    can be used just like dicts as well.
+    """
     if isinstance(batch_list, (list, tuple)):
         for i, batch_list_item in enumerate(batch_list):
             batch_list[i] = recursive_batch_wrap(batch_list_item)
@@ -61,12 +87,16 @@ def recursive_batch_wrap(batch_list):
 
 
 class Stage3BatchWrapper(dict):
+    """
+    Wrapper for a torch_geometric.data.batch.Batch object enabling dict functionality.
+    """
+
     def __init__(self, batch):
         super().__init__(batch.to_dict())
         self._batch = batch
 
     def __getattr__(self, attribute):
-        result = getattr(self._batch, attribute)
-        if isinstance(result, Batch):
-            wrapped_result = Stage3BatchWrapper(result)
-            return wrapped_result
+        return getattr(self._batch, attribute)
+
+    def to(self, device):
+        return Stage3BatchWrapper(self._batch.to(device))

--- a/ocpmodels/modules/exponential_moving_average.py
+++ b/ocpmodels/modules/exponential_moving_average.py
@@ -6,7 +6,6 @@ https://github.com/fadel/pytorch_ema/blob/master/torch_ema/ema.py (MIT license)
 from __future__ import division, unicode_literals
 
 import copy
-import json
 import weakref
 from typing import Iterable, Optional
 

--- a/ocpmodels/trainers/energy_trainer.py
+++ b/ocpmodels/trainers/energy_trainer.py
@@ -13,6 +13,7 @@ import torch_geometric
 from tqdm import tqdm
 
 from ocpmodels.common import distutils
+from ocpmodels.common.deepspeed_utils import deepspeed_trainer_forward
 from ocpmodels.common.registry import registry
 from ocpmodels.tracking import profiler
 from ocpmodels.tracking.profiler import (
@@ -334,6 +335,7 @@ class EnergyTrainer(BaseTrainer):
             self.test_dataset.close_db()
 
     @profiler_phase(Phase.FORWARD)
+    @deepspeed_trainer_forward
     def _forward(self, batch_list):
         output = self.model(batch_list)
 

--- a/ocpmodels/trainers/forces_trainer.py
+++ b/ocpmodels/trainers/forces_trainer.py
@@ -16,6 +16,7 @@ import torch_geometric
 from tqdm import tqdm
 
 from ocpmodels.common import distutils
+from ocpmodels.common.deepspeed_utils import deepspeed_trainer_forward
 from ocpmodels.common.registry import registry
 from ocpmodels.common.relaxation.ml_relaxation import ml_relax
 from ocpmodels.common.utils import check_traj_files
@@ -461,6 +462,7 @@ class ForcesTrainer(BaseTrainer):
             self.test_dataset.close_db()
 
     @profiler_phase(Phase.FORWARD)
+    @deepspeed_trainer_forward
     def _forward(self, batch_list):
         # forward pass.
         if self.config["model_attributes"].get("regress_forces", True):


### PR DESCRIPTION
Removes the necessity to alter the DeepSpeed code in `stage3.py`'s `_apply_to_tensors_only()` method (which procuded countless warning printouts as the tensors in a PyG `Batch` object could not be detected). Before a forward pass using a PyG `Batch` object as input, such a `Batch` object is wrapped by a wrapper class inheriting from `dict`, enabling DeepSpeed Stage 3 to detect the embedded tensors correctly.